### PR TITLE
Update synthese.sql

### DIFF
--- a/chronocapture/synthese.sql
+++ b/chronocapture/synthese.sql
@@ -8,16 +8,57 @@ CREATE VIEW gn_monitoring.vs_chronocapture AS
 WITH source AS (
 	SELECT id_source 
 	FROM gn_synthese.t_sources
-	WHERE name_source = CONCAT('MONITORING_', UPPER(:'module_code')) -- ici 'MONITORING_<module_code>.upper()'
+	WHERE name_source = CONCAT('MONITORING_', UPPER('chronocapture')) -- ici 'MONITORING_<module_code>.upper()'
 	LIMIT 1
+), sites AS (
+
+    SELECT
+
+        id_base_site,
+        uuid_base_site,
+        geom AS the_geom_4326,
+	    ST_CENTROID(geom) AS the_geom_point,
+	    geom_local as geom_local
+
+        FROM gn_monitoring.t_base_sites
+
+), visits AS (
+    
+    SELECT
+    
+        id_base_visit,
+        uuid_base_visit,
+        id_module,
+        id_base_site,
+        id_dataset,
+        id_digitiser,
+
+        visit_date_min AS date_min,
+	    COALESCE (visit_date_max, visit_date_min) AS date_max,
+        comments,
+
+    	id_nomenclature_tech_collect_campanule,
+	    id_nomenclature_grp_typ
+
+        FROM gn_monitoring.t_base_visits
+
+), observers AS (
+    SELECT
+        array_agg(r.id_role) AS ids_observers,
+        STRING_AGG(CONCAT(r.nom_role, ' ', prenom_role), ' ; ') AS observers,
+        id_base_visit
+    FROM gn_monitoring.cor_visit_observer cvo
+    JOIN utilisateurs.t_roles r
+    ON r.id_role = cvo.id_role
+    GROUP BY id_base_visit
 )
 SELECT
 		o.uuid_observation AS unique_id_sinp, 
 		v.uuid_base_visit AS unique_id_sinp_grp,
-		(SELECT id_source FROM source) as id_source,
+		source.id_source,
 		o.id_observation AS entity_source_pk_value,
 		v.id_dataset,
-		v.id_nomenclature_geo_object_nature,
+		ref_nomenclatures.get_id_nomenclature('NAT_OBJ_GEO', 'St') AS id_nomenclature_geo_object_nature,
 		--v.id_nomenclature_grp_typ,
 		ref_nomenclatures.get_id_nomenclature('METH_OBS', '50') AS id_nomenclature_obs_meth,
 		--v.id_nomenclature_obs_technique,
@@ -46,14 +87,14 @@ SELECT
 		--digital_proofvue
 		alt.altitude_min,
 		alt.altitude_max,
-		v.the_geom_4326,
-		v.the_geom_point,
-		v.geom_local as the_geom_local,
+		s.the_geom_4326,	-- v.
+		s.the_geom_point,	-- v.
+		s.geom_local as the_geom_local,	-- v.
 		v.date_min,
 		v.date_max,
 		--validator
 		--validation_comment
-		observers,
+		obs.observers,
 		--determiner
 		v.id_digitiser,
 		(oc.data::json#>'{id_nomenclature_determination_method}')::text::int AS id_nomenclature_determination_method,
@@ -62,16 +103,22 @@ SELECT
 		--meta_update_date,
 		--last_action
 		v.id_module,
-		v.comment_context AS comment_context,
+		v.comments AS comment_context,
 		o.comments AS comment_description,
-		ids_observers,
+		obs.ids_observers,
 		-- ## Colonnes complémentaires pouvant être utile
 		v.id_base_site,
 		v.id_base_visit
-	FROM gn_monitoring.vs_visits v
+
+    FROM gn_monitoring.t_observations o
+    JOIN visits v ON v.id_base_visit = o.id_base_visit
+    JOIN sites s ON s.id_base_site = v.id_base_site
+	JOIN source ON TRUE
+	JOIN observers obs ON obs.id_base_visit = v.id_base_visit
+	--FROM gn_monitoring.vs_visits v
 	JOIN gn_commons.t_modules m ON m.id_module = v.id_module
-	JOIN gn_monitoring.t_observations o ON o.id_base_visit = v.id_base_visit 
+	--JOIN gn_monitoring.t_observations o ON o.id_base_visit = v.id_base_visit 
 	JOIN gn_monitoring.t_observation_complements oc ON oc.id_observation=o.id_observation
 	JOIN taxonomie.taxref t ON t.cd_nom = o.cd_nom
- 	LEFT JOIN LATERAL ref_geo.fct_get_altitude_intersection(v.geom_local) alt (altitude_min, altitude_max) ON true
-    WHERE m.module_code = :'module_code';
+ 	LEFT JOIN LATERAL ref_geo.fct_get_altitude_intersection(s.geom_local) alt (altitude_min, altitude_max) ON true
+    WHERE m.module_code = 'chronocapture';


### PR DESCRIPTION
"gn_monitoring.vs_visits" n'est plus créé dans les nouvelles versions des modules. Adaptation de ce script au regard des fichiers synthese.sql des sous modules cheveches et POPReptile.